### PR TITLE
Fix long string parsing. The first byte/bytes was off by 1 bit.

### DIFF
--- a/src/main/java/net/dongliu/apk/parser/utils/ParseUtils.java
+++ b/src/main/java/net/dongliu/apk/parser/utils/ParseUtils.java
@@ -65,7 +65,7 @@ public class ParseUtils {
         int i = Buffers.readUByte(buffer);
         if ((i & 0x80) != 0) {
             //read one more byte.
-            len |= (i & 0x7f) << 7;
+            len |= (i & 0x7f) << 8;
             len += Buffers.readUByte(buffer);
         } else {
             len = i;
@@ -81,7 +81,7 @@ public class ParseUtils {
         int len = 0;
         int i = Buffers.readUShort(buffer);
         if ((i & 0x8000) != 0) {
-            len |= (i & 0x7fff) << 15;
+            len |= (i & 0x7fff) << 16;
             len += Buffers.readUShort(buffer);
         } else {
             len = i;


### PR DESCRIPTION
It seems that the shift offset was off by one. This issue was reported at openstf/adbkit-apkreader#12 with a sample. I also read the `ENCODE_LENGTH` macro in `StringPool.cpp` and verified that this fix should be correct.