### PR TITLE
Manifest must be parsed after changing preferred locale

### DIFF
--- a/src/main/java/net/dongliu/apk/parser/AbstractApkFile.java
+++ b/src/main/java/net/dongliu/apk/parser/AbstractApkFile.java
@@ -425,6 +425,7 @@ public abstract class AbstractApkFile implements Closeable {
             this.preferredLocale = preferredLocale;
             this.manifestXml = null;
             this.apkMeta = null;
+            this.manifestParsed = false;
         }
     }
 


### PR DESCRIPTION
If preferredLocale changes, getManifestXml() and getMetadata() methods always returns null.

Because "apkMeta" and "manifestXml" are assigned to null but the value of manifestParsed is true so parseManifest method is skipped.