### PR TITLE
Support for long versionCodes

### DIFF
--- a/src/main/java/net/dongliu/apk/parser/parser/ApkMetaTranslator.java
+++ b/src/main/java/net/dongliu/apk/parser/parser/ApkMetaTranslator.java
@@ -79,7 +79,15 @@ public class ApkMetaTranslator implements XmlStreamer {
             case "manifest":
                 apkMetaBuilder.setPackageName(attributes.getString("package"));
                 apkMetaBuilder.setVersionName(attributes.getString("versionName"));
-                apkMetaBuilder.setVersionCode(attributes.getLong("versionCode"));
+                Long majorVersionCode = attributes.getLong("versionCodeMajor");
+                Long versionCode = attributes.getLong("versionCode");
+                if (majorVersionCode != null) {
+                    if (versionCode == null) {
+                        versionCode = 0L;
+                    }
+                    versionCode = (majorVersionCode << 32) | (versionCode & 0xFFFFFFFFL);
+                }
+                apkMetaBuilder.setVersionCode(versionCode);
                 String installLocation = attributes.getString("installLocation");
                 if (installLocation != null) {
                     apkMetaBuilder.setInstallLocation(installLocation);


### PR DESCRIPTION
Luckily, ApkMeta.versionCode is already a `Long`, so I didn't need to add a hacky `versionCodeMajor` field like in android.