### PR TITLE
Don't crash with a buffer underflow when packageCount == 0

### DIFF
--- a/src/main/java/net/dongliu/apk/parser/parser/ResourceTableParser.java
+++ b/src/main/java/net/dongliu/apk/parser/parser/ResourceTableParser.java
@@ -57,11 +57,13 @@ public class ResourceTableParser {
         resourceTable = new ResourceTable();
         resourceTable.setStringPool(stringPool);
 
-        PackageHeader packageHeader = (PackageHeader) readChunkHeader();
-        for (int i = 0; i < resourceTableHeader.getPackageCount(); i++) {
-            Pair<ResourcePackage, PackageHeader> pair = readPackage(packageHeader);
-            resourceTable.addPackage(pair.getLeft());
-            packageHeader = pair.getRight();
+        if (resourceTableHeader.getPackageCount() != 0) {
+            PackageHeader packageHeader = (PackageHeader) readChunkHeader();
+            for (int i = 0; i < resourceTableHeader.getPackageCount(); i++) {
+                Pair<ResourcePackage, PackageHeader> pair = readPackage(packageHeader);
+                resourceTable.addPackage(pair.getLeft());
+                packageHeader = pair.getRight();
+            }
         }
     }
 


### PR DESCRIPTION
This fixes #125

I don't normally see this issue, the particular exception is on `com.citymapper.app.release`, 
 versionCode 1009500, inside `split_kyc2.config.xxxhdpi`